### PR TITLE
Implement authentication microservice

### DIFF
--- a/services/auth/Dockerfile
+++ b/services/auth/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -1,0 +1,26 @@
+# Auth Service
+
+A FastAPI-based microservice implementing the authentication module described in `REQUIREMENTS.md`.
+
+## Features
+- Phone registration and login with SMS verification
+- Email registration with confirmation link
+- Email and phone login issuing JWT access and refresh tokens
+- Password reset via email
+- Logout by invalidating refresh tokens
+
+## Setup
+
+Create a virtual environment and install dependencies:
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run the service:
+```bash
+uvicorn app.main:app --reload
+```
+
+Environment variables can be defined in `.env` or exported in the shell. See `.env.example` in the repository root for common variables.

--- a/services/auth/app/config.py
+++ b/services/auth/app/config.py
@@ -1,0 +1,10 @@
+import os
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    database_url: str = os.getenv("AUTH_DATABASE_URL", "sqlite:///./auth.db")
+    jwt_secret: str = os.getenv("JWT_SECRET", "secret")
+    access_token_ttl: int = 3600  # 1h
+    refresh_token_ttl: int = 30 * 24 * 3600  # 30d
+
+settings = Settings()

--- a/services/auth/app/database.py
+++ b/services/auth/app/database.py
@@ -1,0 +1,10 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from .config import settings
+
+engine = create_engine(settings.database_url, connect_args={"check_same_thread": False} if settings.database_url.startswith("sqlite") else {})
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+Base = declarative_base()
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -1,0 +1,155 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from datetime import datetime, timedelta
+import uuid
+
+from .config import settings
+from .database import SessionLocal, init_db
+from .models import User, SMSCode, RefreshToken, PasswordResetToken
+from .schemas import (
+    SendCodeRequest,
+    VerifyPhoneRequest,
+    EmailRegisterRequest,
+    EmailLoginRequest,
+    ForgotPasswordRequest,
+    ResetPasswordRequest,
+    AuthResponse,
+    UserOut,
+)
+from .utils import hash_password, verify_password, create_access_token, create_refresh_token
+
+init_db()
+app = FastAPI(title="Auth Service")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post("/api/auth/phone/send-code")
+def send_code(data: SendCodeRequest, db: Session = Depends(get_db)):
+    now = datetime.utcnow()
+    last_code = db.query(SMSCode).filter(SMSCode.phone == data.phone).order_by(SMSCode.sent_at.desc()).first()
+    if last_code and (now - last_code.sent_at).total_seconds() < 30:
+        raise HTTPException(status_code=429, detail="Too Many Requests")
+    code = f"{uuid.uuid4().int % 1000000:06d}"
+    sms = SMSCode(phone=data.phone, code=code, sent_at=now)
+    db.add(sms)
+    db.commit()
+    # Placeholder: send SMS via provider
+    return {"message": "Code sent"}
+
+
+@app.post("/api/auth/phone/verify", response_model=AuthResponse)
+def verify_phone(data: VerifyPhoneRequest, db: Session = Depends(get_db)):
+    now = datetime.utcnow()
+    sms = (
+        db.query(SMSCode)
+        .filter(SMSCode.phone == data.phone)
+        .order_by(SMSCode.sent_at.desc())
+        .first()
+    )
+    if not sms or (now - sms.sent_at).total_seconds() > 300 or sms.attempts >= 5:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired code")
+    if sms.code != data.code:
+        sms.attempts += 1
+        db.commit()
+        if sms.attempts >= 5:
+            user = db.query(User).filter(User.phone == data.phone).first()
+            if user:
+                user.blocked_until = now + timedelta(hours=1)
+                db.commit()
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired code")
+
+    user = db.query(User).filter(User.phone == data.phone).first()
+    if not user:
+        if not data.email or not data.password:
+            raise HTTPException(status_code=400, detail="Email and password required for registration")
+        user = User(login_type="phone", phone=data.phone, email=data.email, is_active=True, password_hash=hash_password(data.password))
+        db.add(user)
+        db.commit()
+    elif user.blocked_until and user.blocked_until > now:
+        raise HTTPException(status_code=status.HTTP_423_LOCKED, detail="Phone temporarily blocked")
+    sms.attempts = 0
+    db.commit()
+    access = create_access_token(user.id)
+    refresh_value = create_refresh_token()
+    refresh = RefreshToken(token=refresh_value, user_id=user.id, expires_at=now + timedelta(seconds=settings.refresh_token_ttl * (2 if data.remember_me else 1)))
+    db.add(refresh)
+    db.commit()
+    return AuthResponse(access_token=access, refresh_token=refresh_value, user=UserOut(id=user.id, phone=user.phone, email=user.email, is_active=user.is_active))
+
+
+@app.post("/api/auth/email/register")
+def email_register(data: EmailRegisterRequest, db: Session = Depends(get_db)):
+    if db.query(User).filter(User.email == data.email).first():
+        raise HTTPException(status_code=400, detail="Email already registered")
+    token = str(uuid.uuid4())
+    user = User(login_type="email", email=data.email, password_hash=hash_password(data.password), is_active=False, email_token=token, email_token_expires=datetime.utcnow() + timedelta(hours=24))
+    db.add(user)
+    db.commit()
+    # Placeholder: send email with confirmation link containing token
+    return {"message": "Confirmation sent"}
+
+
+@app.get("/api/auth/email/confirm")
+def email_confirm(token: str, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email_token == token, User.email_token_expires > datetime.utcnow()).first()
+    if not user:
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+    user.is_active = True
+    user.email_token = None
+    user.email_token_expires = None
+    db.query(RefreshToken).filter(RefreshToken.user_id == user.id).delete()
+    db.commit()
+    return {"message": "Email confirmed"}
+
+
+@app.post("/api/auth/email/login", response_model=AuthResponse)
+def email_login(data: EmailLoginRequest, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == data.email, User.login_type == "email").first()
+    if not user or not verify_password(data.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    access = create_access_token(user.id)
+    now = datetime.utcnow()
+    refresh_value = create_refresh_token()
+    refresh = RefreshToken(token=refresh_value, user_id=user.id, expires_at=now + timedelta(seconds=settings.refresh_token_ttl * (2 if data.remember_me else 1)))
+    db.add(refresh)
+    db.commit()
+    return AuthResponse(access_token=access, refresh_token=refresh_value, user=UserOut(id=user.id, phone=user.phone, email=user.email, is_active=user.is_active))
+
+
+@app.post("/api/auth/email/forgot")
+def forgot_password(data: ForgotPasswordRequest, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == data.email).first()
+    if user:
+        token = str(uuid.uuid4())
+        reset = PasswordResetToken(token=token, user_id=user.id, expires_at=datetime.utcnow() + timedelta(minutes=15))
+        db.merge(reset)
+        db.commit()
+        # Placeholder: send email with reset token
+    return {"message": "If email exists, reset link sent"}
+
+
+@app.post("/api/auth/email/reset")
+def reset_password(data: ResetPasswordRequest, db: Session = Depends(get_db)):
+    reset = db.query(PasswordResetToken).filter(PasswordResetToken.token == data.token, PasswordResetToken.expires_at > datetime.utcnow()).first()
+    if not reset:
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+    user = db.query(User).filter(User.id == reset.user_id).first()
+    user.password_hash = hash_password(data.new_password)
+    db.query(RefreshToken).filter(RefreshToken.user_id == user.id).delete()
+    db.delete(reset)
+    db.commit()
+    return {"message": "Password updated"}
+
+
+@app.post("/api/auth/logout")
+def logout(refresh_token: str, db: Session = Depends(get_db)):
+    db.query(RefreshToken).filter(RefreshToken.token == refresh_token).delete()
+    db.commit()
+    return {"message": "Logged out"}

--- a/services/auth/app/models.py
+++ b/services/auth/app/models.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime, timedelta
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, Integer, CHAR
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from .database import Base
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    login_type = Column(String(10), nullable=False)
+    phone = Column(String(15), unique=True)
+    email = Column(String(255), unique=True)
+    password_hash = Column(String(255))
+    is_active = Column(Boolean, default=False)
+    blocked_until = Column(DateTime)
+    email_token = Column(String(36))
+    email_token_expires = Column(DateTime)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+class SMSCode(Base):
+    __tablename__ = 'sms_codes'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    phone = Column(String(15), nullable=False)
+    code = Column(CHAR(6), nullable=False)
+    sent_at = Column(DateTime, default=datetime.utcnow)
+    attempts = Column(Integer, default=0)
+
+class RefreshToken(Base):
+    __tablename__ = 'refresh_tokens'
+    token = Column(CHAR(64), primary_key=True)
+    user_id = Column(String(36), ForeignKey('users.id', ondelete='CASCADE'))
+    expires_at = Column(DateTime, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+class PasswordResetToken(Base):
+    __tablename__ = 'password_reset_tokens'
+    token = Column(String(36), primary_key=True)
+    user_id = Column(String(36), ForeignKey('users.id', ondelete='CASCADE'))
+    expires_at = Column(DateTime, nullable=False)

--- a/services/auth/app/schemas.py
+++ b/services/auth/app/schemas.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from pydantic import BaseModel, EmailStr, constr
+
+class SendCodeRequest(BaseModel):
+    phone: constr(regex=r'^\+7\d{10}$')
+
+class VerifyPhoneRequest(BaseModel):
+    phone: constr(regex=r'^\+7\d{10}$')
+    code: constr(min_length=6, max_length=6)
+    email: EmailStr | None = None
+    password: str | None = None
+    remember_me: bool = False
+
+class EmailRegisterRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+class EmailLoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+    remember_me: bool = False
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+class UserOut(BaseModel):
+    id: str
+    phone: str | None = None
+    email: str | None = None
+    is_active: bool
+
+class AuthResponse(TokenResponse):
+    user: UserOut

--- a/services/auth/app/utils.py
+++ b/services/auth/app/utils.py
@@ -1,0 +1,26 @@
+import os
+import uuid
+from datetime import datetime, timedelta
+from passlib.hash import bcrypt
+import jwt
+from .config import settings
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return bcrypt.verify(password, hashed)
+
+
+def create_access_token(user_id: str) -> str:
+    payload = {
+        "sub": user_id,
+        "exp": datetime.utcnow() + timedelta(seconds=settings.access_token_ttl),
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
+
+
+def create_refresh_token() -> str:
+    return uuid.uuid4().hex + uuid.uuid4().hex

--- a/services/auth/requirements.txt
+++ b/services/auth/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+passlib[bcrypt]
+PyJWT
+python-dotenv
+pytest

--- a/services/auth/tests/test_utils.py
+++ b/services/auth/tests/test_utils.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'app'))
+
+from utils import hash_password, verify_password, create_access_token
+
+
+def test_password_hashing():
+    pw = 'secret'
+    hashed = hash_password(pw)
+    assert verify_password(pw, hashed)
+
+
+def test_access_token():
+    token = create_access_token('user')
+    assert token


### PR DESCRIPTION
## Summary
- add Auth service implementing phone/email registration flows
- generate JWT tokens and refresh tokens
- provide FastAPI endpoints per requirements
- document setup in README
- add basic unit tests (fail due to missing dependencies in sandbox)

## Testing
- `python -m pytest services/auth/tests/test_utils.py -q` *(fails: ModuleNotFoundError: No module named 'passlib')*

------
https://chatgpt.com/codex/tasks/task_e_686a57b296508330a1646c2c77e6b775