### PR TITLE
Add initial Profile service skeleton

### DIFF
--- a/services/profile/Dockerfile
+++ b/services/profile/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/profile/README.md
+++ b/services/profile/README.md
@@ -1,0 +1,30 @@
+# Profile Service
+
+This is a minimal implementation of the Profile and Social Accounts module described in `REQUIREMENTS.md`.
+
+The service uses **FastAPI** and **SQLAlchemy**. The default database is SQLite for local development, but `PROFILE_DATABASE_URL` can point to PostgreSQL in production.
+
+## Endpoints
+
+- `GET /api/profile?user_id=` — retrieve profile and linked social accounts
+- `PUT /api/profile?user_id=` — update profile fields
+- `POST /api/profile/avatar?user_id=` — upload avatar image (≤5MB)
+- `GET/POST/PUT/DELETE /api/experience-levels` — CRUD operations for experience levels
+- `POST /api/profile/social/link` — link a social account
+- `DELETE /api/profile/social/{provider}?user_id=` — unlink
+- `GET /api/profile/history?user_id=&page=&per_page=` — change history
+
+Launch locally with:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Running Tests
+
+Use `pytest` from the repository root:
+
+```bash
+pytest services/profile/tests
+```
+

--- a/services/profile/app/crud.py
+++ b/services/profile/app/crud.py
@@ -1,0 +1,102 @@
+from sqlalchemy.orm import Session
+from . import models, schemas
+from typing import List
+from uuid import UUID, uuid4
+
+
+def get_profile(db: Session, user_id: UUID) -> models.Profile:
+    return db.query(models.Profile).filter(models.Profile.user_id == user_id).first()
+
+
+def create_profile(db: Session, profile_in: schemas.ProfileCreate) -> models.Profile:
+    profile = models.Profile(
+        user_id=profile_in.user_id or uuid4(),
+        first_name=profile_in.first_name,
+        nickname=profile_in.nickname,
+        birth_date=profile_in.birth_date,
+        gender=profile_in.gender,
+        country=profile_in.country,
+        city=profile_in.city,
+        company=profile_in.company,
+        position=profile_in.position,
+        experience_id=profile_in.experience_id,
+        avatar_url=profile_in.avatar_url,
+    )
+    db.add(profile)
+    db.commit()
+    db.refresh(profile)
+    return profile
+
+
+def update_profile(db: Session, profile: models.Profile, update_in: schemas.ProfileUpdate, changed_by: UUID):
+    for field, value in update_in.dict(exclude_unset=True).items():
+        old_value = getattr(profile, field)
+        if value != old_value:
+            setattr(profile, field, value)
+            history = models.ProfileHistory(
+                user_id=profile.user_id,
+                field=field,
+                old_value=str(old_value) if old_value is not None else None,
+                new_value=str(value) if value is not None else None,
+                changed_by=changed_by,
+            )
+            db.add(history)
+    db.commit()
+    db.refresh(profile)
+    return profile
+
+
+def list_experience_levels(db: Session) -> List[models.ExperienceLevel]:
+    return db.query(models.ExperienceLevel).order_by(models.ExperienceLevel.sequence).all()
+
+
+def create_experience_level(db: Session, level: schemas.ExperienceLevelBase) -> models.ExperienceLevel:
+    obj = models.ExperienceLevel(label=level.label, sequence=level.sequence)
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def update_experience_level(db: Session, exp_id: int, level: schemas.ExperienceLevelBase) -> models.ExperienceLevel:
+    obj = db.query(models.ExperienceLevel).get(exp_id)
+    if not obj:
+        return None
+    obj.label = level.label
+    obj.sequence = level.sequence
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def delete_experience_level(db: Session, exp_id: int):
+    obj = db.query(models.ExperienceLevel).get(exp_id)
+    if obj:
+        db.delete(obj)
+        db.commit()
+
+
+def link_social(db: Session, user_id: UUID, provider: str, provider_id: str) -> models.SocialBinding:
+    binding = models.SocialBinding(user_id=user_id, provider=provider, provider_id=provider_id)
+    db.add(binding)
+    db.commit()
+    db.refresh(binding)
+    return binding
+
+
+def unlink_social(db: Session, user_id: UUID, provider: str):
+    binding = db.query(models.SocialBinding).filter_by(user_id=user_id, provider=provider).first()
+    if binding:
+        db.delete(binding)
+        db.commit()
+
+
+def list_history(db: Session, user_id: UUID, skip: int = 0, limit: int = 20) -> List[models.ProfileHistory]:
+    return (
+        db.query(models.ProfileHistory)
+        .filter(models.ProfileHistory.user_id == user_id)
+        .order_by(models.ProfileHistory.changed_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )

--- a/services/profile/app/database.py
+++ b/services/profile/app/database.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+DATABASE_URL = os.getenv("PROFILE_DATABASE_URL", "sqlite:///./profile.db")
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {})
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+

--- a/services/profile/app/main.py
+++ b/services/profile/app/main.py
@@ -1,0 +1,98 @@
+from fastapi import FastAPI, Depends, HTTPException, UploadFile, File
+from sqlalchemy.orm import Session
+from uuid import UUID
+from typing import List
+import shutil
+import os
+
+from .database import SessionLocal, engine, Base
+from . import models, schemas, crud
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Profile Service")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.get("/api/profile", response_model=schemas.ProfileOut)
+def read_profile(user_id: UUID, db: Session = Depends(get_db)):
+    profile = crud.get_profile(db, user_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+
+@app.put("/api/profile", response_model=schemas.ProfileOut)
+def update_profile(user_id: UUID, profile_update: schemas.ProfileUpdate, db: Session = Depends(get_db)):
+    profile = crud.get_profile(db, user_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    updated = crud.update_profile(db, profile, profile_update, changed_by=user_id)
+    return updated
+
+
+@app.post("/api/profile/avatar", response_model=dict)
+def upload_avatar(user_id: UUID, file: UploadFile = File(...), db: Session = Depends(get_db)):
+    if file.content_type not in ("image/jpeg", "image/png"):
+        raise HTTPException(status_code=400, detail="Invalid image type")
+    contents = file.file.read()
+    if len(contents) > 5 * 1024 * 1024:
+        raise HTTPException(status_code=400, detail="File too large")
+    path = f"avatars/{user_id}_{file.filename}"
+    os.makedirs("avatars", exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(contents)
+    profile = crud.get_profile(db, user_id)
+    if not profile:
+        profile = crud.create_profile(db, schemas.ProfileCreate(user_id=user_id, first_name=""))
+    crud.update_profile(db, profile, schemas.ProfileUpdate(avatar_url=path), changed_by=user_id)
+    return {"avatar_url": path}
+
+
+@app.get("/api/experience-levels", response_model=List[schemas.ExperienceLevelOut])
+def list_levels(db: Session = Depends(get_db)):
+    return crud.list_experience_levels(db)
+
+
+@app.post("/api/experience-levels", response_model=schemas.ExperienceLevelOut)
+def create_level(level: schemas.ExperienceLevelBase, db: Session = Depends(get_db)):
+    return crud.create_experience_level(db, level)
+
+
+@app.put("/api/experience-levels/{level_id}", response_model=schemas.ExperienceLevelOut)
+def update_level(level_id: int, level: schemas.ExperienceLevelBase, db: Session = Depends(get_db)):
+    updated = crud.update_experience_level(db, level_id, level)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Not found")
+    return updated
+
+
+@app.delete("/api/experience-levels/{level_id}")
+def delete_level(level_id: int, db: Session = Depends(get_db)):
+    crud.delete_experience_level(db, level_id)
+    return {"ok": True}
+
+
+@app.post("/api/profile/social/link", response_model=schemas.SocialBindingOut)
+def link_social(user_id: UUID, provider: str, provider_id: str, db: Session = Depends(get_db)):
+    return crud.link_social(db, user_id, provider, provider_id)
+
+
+@app.delete("/api/profile/social/{provider}")
+def unlink_social(provider: str, user_id: UUID, db: Session = Depends(get_db)):
+    crud.unlink_social(db, user_id, provider)
+    return {"ok": True}
+
+
+@app.get("/api/profile/history", response_model=List[schemas.ProfileHistoryOut])
+def profile_history(user_id: UUID, page: int = 1, per_page: int = 20, db: Session = Depends(get_db)):
+    skip = (page - 1) * per_page
+    return crud.list_history(db, user_id, skip=skip, limit=per_page)
+

--- a/services/profile/app/models.py
+++ b/services/profile/app/models.py
@@ -1,0 +1,55 @@
+from sqlalchemy import Column, String, Date, Integer, ForeignKey, DateTime, func, Enum, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+import uuid
+
+from .database import Base
+
+
+class ExperienceLevel(Base):
+    __tablename__ = "experience_levels"
+    id = Column(Integer, primary_key=True, index=True)
+    label = Column(String(50), nullable=False)
+    sequence = Column(Integer, nullable=False)
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+    user_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    first_name = Column(String(100), nullable=False)
+    nickname = Column(String(50))
+    birth_date = Column(Date)
+    gender = Column(String(10))
+    country = Column(String(100))
+    city = Column(String(100))
+    company = Column(String(150))
+    position = Column(String(150))
+    experience_id = Column(Integer, ForeignKey("experience_levels.id"))
+    avatar_url = Column(String(255))
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    experience = relationship("ExperienceLevel")
+    social_accounts = relationship("SocialBinding", back_populates="profile")
+
+
+class SocialBinding(Base):
+    __tablename__ = "social_bindings"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("profiles.user_id"))
+    provider = Column(String(20), nullable=False)
+    provider_id = Column(String(255), nullable=False)
+    linked_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    profile = relationship("Profile", back_populates="social_accounts")
+
+
+class ProfileHistory(Base):
+    __tablename__ = "profile_history"
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("profiles.user_id"))
+    field = Column(String(50), nullable=False)
+    old_value = Column(Text)
+    new_value = Column(Text)
+    changed_at = Column(DateTime(timezone=True), server_default=func.now())
+    changed_by = Column(UUID(as_uuid=True), nullable=True)
+

--- a/services/profile/app/schemas.py
+++ b/services/profile/app/schemas.py
@@ -1,0 +1,65 @@
+from datetime import date, datetime
+from typing import Optional, List
+from pydantic import BaseModel, Field
+from uuid import UUID
+
+
+class SocialBindingOut(BaseModel):
+    provider: str
+    provider_id: str
+    linked_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class ProfileBase(BaseModel):
+    first_name: str
+    nickname: Optional[str] = None
+    birth_date: Optional[date] = None
+    gender: Optional[str] = Field(None, regex="^(male|female|other)$")
+    country: Optional[str] = None
+    city: Optional[str] = None
+    company: Optional[str] = None
+    position: Optional[str] = None
+    experience_id: Optional[int] = None
+    avatar_url: Optional[str] = None
+
+
+class ProfileCreate(ProfileBase):
+    user_id: Optional[UUID] = None
+
+
+class ProfileUpdate(ProfileBase):
+    pass
+
+
+class ProfileOut(ProfileBase):
+    user_id: UUID
+    social_accounts: List[SocialBindingOut] = []
+
+    class Config:
+        orm_mode = True
+
+
+class ExperienceLevelBase(BaseModel):
+    label: str
+    sequence: int
+
+
+class ExperienceLevelOut(ExperienceLevelBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ProfileHistoryOut(BaseModel):
+    field: str
+    old_value: Optional[str]
+    new_value: Optional[str]
+    changed_at: datetime
+
+    class Config:
+        orm_mode = True
+

--- a/services/profile/requirements.txt
+++ b/services/profile/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn==0.27.0
+SQLAlchemy==2.0.29
+pydantic==1.10.13
+python-multipart==0.0.9

--- a/services/profile/tests/test_profile.py
+++ b/services/profile/tests/test_profile.py
@@ -1,0 +1,37 @@
+import uuid
+from fastapi.testclient import TestClient
+from services.profile.app.main import app, Base, engine, SessionLocal
+from services.profile.app import models
+
+Base.metadata.create_all(bind=engine)
+
+client = TestClient(app)
+
+
+def test_create_and_read_profile():
+    db = SessionLocal()
+    profile = models.Profile(user_id=uuid.uuid4(), first_name="John")
+    db.add(profile)
+    db.commit()
+    user_id = profile.user_id
+    db.close()
+
+    response = client.get(f"/api/profile?user_id={user_id}")
+    assert response.status_code == 200
+    assert response.json()["user_id"] == str(user_id)
+
+
+def test_experience_level_crud():
+    response = client.post("/api/experience-levels", json={"label": "Junior", "sequence": 1})
+    assert response.status_code == 200
+    level_id = response.json()["id"]
+
+    response = client.get("/api/experience-levels")
+    assert response.status_code == 200
+    assert len(response.json()) >= 1
+
+    response = client.put(f"/api/experience-levels/{level_id}", json={"label": "Junior+", "sequence": 1})
+    assert response.status_code == 200
+
+    response = client.delete(f"/api/experience-levels/{level_id}")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- scaffold a new Profile microservice under `services/profile`
- add SQLAlchemy models and CRUD helpers
- implement FastAPI application with profile and social endpoints
- include a simple Dockerfile and tests

## Testing
- `pip install -r services/profile/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q services/profile/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686a5876f38083308de3c8192e58113b