### PR TITLE
Add docker-compose for all services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,101 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./docker/postgres-init:/docker-entrypoint-initdb.d
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+
+  auth:
+    build: ./services/auth
+    env_file: .env
+    depends_on:
+      - postgres
+    ports:
+      - "8001:8000"
+
+  profile:
+    build: ./services/profile
+    env_file: .env
+    depends_on:
+      - postgres
+    ports:
+      - "8002:8000"
+
+  content:
+    build: ./services/content
+    env_file: .env
+    depends_on:
+      - postgres
+    ports:
+      - "8003:8000"
+
+  chat:
+    build: ./services/chat
+    env_file: .env
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - "8004:3000"
+
+  notification:
+    build: ./services/notification
+    env_file: .env
+    depends_on:
+      - postgres
+      - redis
+      - rabbitmq
+    ports:
+      - "8005:8000"
+
+  analytics:
+    build: ./services/analytics
+    env_file: .env
+    depends_on:
+      - postgres
+      - rabbitmq
+    ports:
+      - "8006:8000"
+
+  notification-worker:
+    build: ./services/notification
+    env_file: .env
+    depends_on:
+      - notification
+      - rabbitmq
+      - redis
+    command: celery -A tasks.celery_app worker --loglevel=info
+
+  analytics-worker:
+    build: ./services/analytics
+    env_file: .env
+    depends_on:
+      - analytics
+      - rabbitmq
+    command: celery -A app.tasks worker -B --loglevel=info
+
+volumes:
+  postgres-data:
+  redis-data:
+  rabbitmq-data:

--- a/docker/postgres-init/init.sql
+++ b/docker/postgres-init/init.sql
@@ -1,0 +1,6 @@
+CREATE DATABASE auth_db;
+CREATE DATABASE profile_db;
+CREATE DATABASE content_db;
+CREATE DATABASE notification_db;
+CREATE DATABASE chat_db;
+CREATE DATABASE analytics_db;

--- a/services/analytics/tests/test_api.py
+++ b/services/analytics/tests/test_api.py
@@ -1,6 +1,11 @@
 import os
+import sys
 import uuid
+from pathlib import Path
 from fastapi.testclient import TestClient
+
+# Ensure package imports work when running via pytest
+sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 DB_PATH = "analytics_test.db"
 if os.path.exists(DB_PATH):

--- a/services/chat/Dockerfile
+++ b/services/chat/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+CMD ["npm", "start"]

--- a/services/content/Dockerfile
+++ b/services/content/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.21-alpine
+WORKDIR /app
+COPY go.mod .
+COPY main.go .
+RUN go mod download
+COPY . .
+RUN go build -o content .
+CMD ["./content"]

--- a/services/notification/Dockerfile
+++ b/services/notification/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- support running all microservices in development with docker-compose
- add init script for local Postgres databases
- add Dockerfiles for services without one
- fix analytics tests by appending repo root to `sys.path`

## Testing
- `pytest services/auth/tests`
- `pytest services/profile/tests`
- `pytest services/analytics/tests`
- `PYTHONPATH=$PYTHONPATH:`pwd` pytest services/notification/tests`
- `npm test` in `services/chat`
- `go test ./...` in `services/content`


------
https://chatgpt.com/codex/tasks/task_e_686a76b92bd483308273ff0a54aa607e