### PR TITLE
Fix chat service start failure due to missing deps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - notification
       - rabbitmq
       - redis
-    command: celery -A tasks.celery_app worker --loglevel=info
+    command: celery -A notification.tasks.celery_app worker --loglevel=info
 
   analytics-worker:
     build: ./services/analytics

--- a/services/auth/requirements.txt
+++ b/services/auth/requirements.txt
@@ -6,4 +6,5 @@ pydantic-settings
 passlib[bcrypt]
 PyJWT
 python-dotenv
+psycopg2-binary
 pytest

--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -11,6 +11,12 @@ service is intentionally lightweight and meant for local experimentation.
    ```bash
    npm install
    ```
+If you start the service without running this command you will see the
+message `sequelize not installed, using stub models` and the server will fail
+to initialize.
+When using Docker Compose make sure to run
+`docker compose up --build` so the image installs all dependencies during the
+build step.
 2. Start the server:
    ```bash
    npm start

--- a/services/notification/Dockerfile
+++ b/services/notification/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "notification.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/profile/requirements.txt
+++ b/services/profile/requirements.txt
@@ -3,3 +3,5 @@ uvicorn==0.27.0
 SQLAlchemy==2.0.29
 pydantic==2.11.7
 python-multipart==0.0.9
+psycopg2-binary
+httpx


### PR DESCRIPTION
## Summary
- clarify that `npm install` must be executed before starting the chat service to avoid the `sequelize not installed` error
- run `docker compose up --build` to install Node deps when using Docker
- include missing PostgreSQL drivers in Python services
- use package module paths for notification service
- fix celery worker command in compose file

## Testing
- `npm test --prefix services/chat`
- `pytest services/auth/tests`
- `PYTHONPATH=. pytest services/profile/tests`
- `PYTHONPATH=. pytest services/notification/tests`
- `PYTHONPATH=. pytest services/analytics/tests`


------
https://chatgpt.com/codex/tasks/task_e_686a7e0118d883308646a796b7e247e9