### PR TITLE
Fix Notification service imports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - notification
       - rabbitmq
       - redis
-    command: celery -A notification.tasks.celery_app worker --loglevel=info
+    command: celery -A tasks.celery_app worker --loglevel=info
 
   analytics-worker:
     build: ./services/analytics

--- a/services/notification/Dockerfile
+++ b/services/notification/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "notification.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/notification/requirements.txt
+++ b/services/notification/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.110.0
 uvicorn==0.27.0
 SQLAlchemy==2.0.29
 asyncpg==0.29.0
-pydantic==2.6.4
+pydantic==2.11.7
 python-dotenv==1.0.1
 celery==5.3.6
 redis==5.0.1


### PR DESCRIPTION
## Summary
- fix notification image command
- run Celery worker with package-local path
- update pydantic version for notification service

## Testing
- `pytest services/auth/tests`
- `pytest services/profile/tests`
- `pytest services/analytics/tests`
- `PYTHONPATH=$PWD pytest services/notification/tests`
- `npm install` & `npm test` in `services/chat`
- `go test ./...` in `services/content`

------
https://chatgpt.com/codex/tasks/task_e_686a89f6c5508330b5bb6bdd7c2eedda