### PR TITLE
Fix auth container email validator issue

### DIFF
--- a/services/auth/requirements.txt
+++ b/services/auth/requirements.txt
@@ -8,3 +8,4 @@ PyJWT
 python-dotenv
 psycopg2-binary
 pytest
+email-validator

--- a/services/notification/tests/test_notification.py
+++ b/services/notification/tests/test_notification.py
@@ -1,7 +1,13 @@
 import os
+import sys
 import uuid
 import asyncio
+from pathlib import Path
 from fastapi.testclient import TestClient
+
+# Add repository root to the path so ``services`` can be imported as a package
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))
 
 DB_PATH = "notification_test.db"
 if os.path.exists(DB_PATH):


### PR DESCRIPTION
## Summary
- add `email-validator` dependency to Auth service
- ensure Notification tests can import services package

## Testing
- `pytest services/auth/tests`
- `pytest services/profile/tests`
- `pytest services/analytics/tests`
- `pytest services/notification/tests`
- `go test` in `services/content`
- `npm test` in `services/chat`

------
https://chatgpt.com/codex/tasks/task_e_686b7506ff30833084e3a7cff571add5