### PR TITLE
Fix example notification DB driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ OBJECT_STORAGE_ACCESS_KEY=access_key
 OBJECT_STORAGE_SECRET_KEY=secret_key
 
 # Notification Service
-NOTIFICATION_DATABASE_URL=postgresql://user:password@localhost:5432/notification_db
+NOTIFICATION_DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/notification_db
 REDIS_URL=redis://localhost:6379/0
 RABBITMQ_URL=amqp://guest:guest@localhost:5672/
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token

--- a/services/notification/README.md
+++ b/services/notification/README.md
@@ -14,3 +14,6 @@ as a starting point for further development.
 
 The service relies on PostgreSQL for persistent storage and RabbitMQ/Redis for the task queue.
 Environment variables are loaded from the surrounding project `.env` file.
+Ensure that `NOTIFICATION_DATABASE_URL` uses the `asyncpg` driver, e.g.
+`postgresql+asyncpg://user:password@localhost:5432/notification_db`, so that the
+async SQLAlchemy engine can connect without requiring the `psycopg2` package.


### PR DESCRIPTION
## Summary
- use `postgresql+asyncpg://` for notification DB URL in example env file
- document driver requirement in the notification service README

## Testing
- `pip install -q -r services/auth/requirements.txt`
- `pip install -q -r services/profile/requirements.txt`
- `pip install -q -r services/analytics/requirements.txt`
- `pip install -q -r services/notification/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b75219d7c83308a198a140f75e15d