### PR TITLE
Add gateway docs and EFK setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,18 @@ documentation in this repository to continue building out the platform.
   with example tests in `services/notification/tests`.
 - **Analytics service** – `services/analytics` (Python/FastAPI + Celery) with
   example tests in `services/analytics/tests`.
+
+## API Gateway
+
+The architecture routes all incoming traffic through an API gateway. As noted in
+`REQUIREMENTS.md` line 21, this gateway validates JWT tokens, terminates TLS and
+forwards requests to the microservices. A minimal Nginx example is provided in
+[`docker/nginx/app.conf`](docker/nginx/app.conf).
+
+## Centralized Logging with EFK
+
+Lines 31 and 532 of `REQUIREMENTS.md` specify the use of an EFK (Elasticsearch,
+Fluentd, Kibana) stack for aggregating service logs. Deploy Elasticsearch and
+Fluentd, expose Kibana (for example on port 5601) and configure Fluentd to
+forward container output. Once deployed, open Kibana to search and visualize
+logs from every service.

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -118,3 +118,7 @@ docker compose up --build
 Each service exposes its API on the port defined by the `PORT` environment
 variable.
 
+
+## 7. Gateway and Logging
+
+The platform routes requests through an API gateway. See the [API Gateway section](README.md#api-gateway) in the README along with the sample configuration in [`docker/nginx/app.conf`](docker/nginx/app.conf). For log viewing instructions refer to [Centralized Logging with EFK](README.md#centralized-logging-with-efk).

--- a/docker/nginx/app.conf
+++ b/docker/nginx/app.conf
@@ -1,0 +1,34 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    # Uncomment and provide certificates for TLS termination
+    # listen 443 ssl;
+    # ssl_certificate /etc/nginx/certs/server.crt;
+    # ssl_certificate_key /etc/nginx/certs/server.key;
+
+    location /auth/ {
+        proxy_pass http://auth:8000/;
+        proxy_set_header Host $host;
+    }
+    location /profile/ {
+        proxy_pass http://profile:8000/;
+        proxy_set_header Host $host;
+    }
+    location /content/ {
+        proxy_pass http://content:8000/;
+        proxy_set_header Host $host;
+    }
+    location /chat/ {
+        proxy_pass http://chat:3000/;
+        proxy_set_header Host $host;
+    }
+    location /notification/ {
+        proxy_pass http://notification:8000/;
+        proxy_set_header Host $host;
+    }
+    location /analytics/ {
+        proxy_pass http://analytics:8000/;
+        proxy_set_header Host $host;
+    }
+}


### PR DESCRIPTION
## Summary
- note that an API gateway (e.g. Nginx) is used for TLS termination and routing
- add sample Nginx reverse proxy config
- document how to deploy the EFK stack for log viewing
- cross-link the new instructions from the setup guide

## Testing
- `pytest services/auth/tests services/profile/tests services/analytics/tests services/notification/tests -q`
- `npm test` in `services/chat`
- `go test ./...` in `services/content`


------
https://chatgpt.com/codex/tasks/task_e_686b9a206bd8833083739ee19fd1f7b8