### PR TITLE
Improve nginx config and document gateway endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ forwards requests to the microservices. A minimal Nginx example is provided in
 `docker-compose.yml` starts a `gateway` service using this file so the platform
 is reachable at `http://localhost:8080`.
 
+### Accessing Services via the Gateway
+
+After running `docker compose up --build` you can browse each module through
+Nginx using the following paths:
+
+| Service         | Endpoint                               |
+|-----------------|-----------------------------------------|
+| Auth            | `http://localhost:8080/auth/docs`       |
+| Profile         | `http://localhost:8080/profile/docs`    |
+| Content         | `http://localhost:8080/content/docs`    |
+| Chat            | `http://localhost:8080/chat/docs`       |
+| Notification    | `http://localhost:8080/notification/docs` |
+| Analytics       | `http://localhost:8080/analytics/docs`  |
+
+Each service exposes its own Swagger UI under `/docs` for interactive API
+testing. Replace `/docs` with other paths as appropriate for your implementation.
+
 ## Centralized Logging with EFK
 
 Lines 31 and 532 of `REQUIREMENTS.md` specify the use of an EFK (Elasticsearch,

--- a/docker/nginx/app.conf
+++ b/docker/nginx/app.conf
@@ -7,28 +7,52 @@ server {
     # ssl_certificate /etc/nginx/certs/server.crt;
     # ssl_certificate_key /etc/nginx/certs/server.key;
 
+    # allow uploads up to 20 MB (adjust as needed)
+    client_max_body_size 20m;
+
     location /auth/ {
         proxy_pass http://auth:8000/;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
     location /profile/ {
         proxy_pass http://profile:8000/;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
     location /content/ {
         proxy_pass http://content:8000/;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
     location /chat/ {
         proxy_pass http://chat:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
     location /notification/ {
         proxy_pass http://notification:8000/;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
     location /analytics/ {
         proxy_pass http://analytics:8000/;
         proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
## Summary
- extend nginx config with real IP headers, a larger body size, and WebSocket support
- document service URLs exposed through the gateway

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686babf251bc8330874397fb5fe45355