### PR TITLE
Fix swagger path

### DIFF
--- a/services/content/main.go
+++ b/services/content/main.go
@@ -422,7 +422,7 @@ func docsHandler(w http.ResponseWriter, r *http.Request) {
 <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui-bundle.js"></script>
 <script>
 window.onload = function() {
-  SwaggerUIBundle({url: '/docs/swagger.json', dom_id: '#swagger-ui'});
+  SwaggerUIBundle({url: 'swagger.json', dom_id: '#swagger-ui'});
 };
 </script>
 </body>


### PR DESCRIPTION
## Summary
- serve Swagger spec with a relative URL in the docs handler

## Testing
- `go test`

------
https://chatgpt.com/codex/tasks/task_e_686bc2339e488330a4477154d07dfdff