### PR TITLE
Add ROOT_PATH configuration to services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
   auth:
     build: ./services/auth
     env_file: .env
+    environment:
+      ROOT_PATH: /auth
     depends_on:
       - postgres
     ports:
@@ -37,6 +39,8 @@ services:
   profile:
     build: ./services/profile
     env_file: .env
+    environment:
+      ROOT_PATH: /profile
     depends_on:
       - postgres
     ports:
@@ -62,6 +66,8 @@ services:
   notification:
     build: ./services/notification
     env_file: .env
+    environment:
+      ROOT_PATH: /notification
     depends_on:
       - postgres
       - redis
@@ -72,6 +78,8 @@ services:
   analytics:
     build: ./services/analytics
     env_file: .env
+    environment:
+      ROOT_PATH: /analytics
     depends_on:
       - postgres
       - rabbitmq

--- a/services/analytics/app/main.py
+++ b/services/analytics/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
+import os
 from .api import router as analytics_router
 
-app = FastAPI(title="Analytics Service")
+app = FastAPI(title="Analytics Service", root_path=os.getenv("ROOT_PATH", ""))
 app.include_router(analytics_router)

--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta
 import uuid
+import os
 
 from .config import settings
 from .database import SessionLocal, init_db
@@ -19,7 +20,7 @@ from .schemas import (
 from .utils import hash_password, verify_password, create_access_token, create_refresh_token
 
 init_db()
-app = FastAPI(title="Auth Service")
+app = FastAPI(title="Auth Service", root_path=os.getenv("ROOT_PATH", ""))
 
 
 def get_db():

--- a/services/notification/app/main.py
+++ b/services/notification/app/main.py
@@ -8,7 +8,7 @@ from typing import List
 from .database import get_session, Base, engine
 from . import crud, schemas, models
 
-app = FastAPI(title="Notification Service")
+app = FastAPI(title="Notification Service", root_path=os.getenv("ROOT_PATH", ""))
 
 app.add_middleware(
     CORSMiddleware,

--- a/services/profile/app/main.py
+++ b/services/profile/app/main.py
@@ -10,7 +10,7 @@ from . import models, schemas, crud
 
 Base.metadata.create_all(bind=engine)
 
-app = FastAPI(title="Profile Service")
+app = FastAPI(title="Profile Service", root_path=os.getenv("ROOT_PATH", ""))
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- pass ROOT_PATH env var to FastAPI apps
- set ROOT_PATH for microservices in docker-compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc23c57008330aaf4463a8e4a49b0