### PR TITLE
Fix Swagger docs paths

### DIFF
--- a/services/analytics/app/main.py
+++ b/services/analytics/app/main.py
@@ -2,12 +2,12 @@ from fastapi import FastAPI
 import os
 from .api import router as analytics_router
 
-ROOT_PATH = os.getenv("ROOT_PATH", "/analytics")
+ROOT_PATH = os.getenv("ROOT_PATH", "")
 app = FastAPI(
     title="Analytics Service",
     root_path=ROOT_PATH,
-    docs_url=f"{ROOT_PATH}/docs" if ROOT_PATH else "/docs",
-    redoc_url=f"{ROOT_PATH}/redoc" if ROOT_PATH else "/redoc",
-    openapi_url=f"{ROOT_PATH}/openapi.json" if ROOT_PATH else "/openapi.json",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
 )
 app.include_router(analytics_router)

--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -20,13 +20,13 @@ from .schemas import (
 from .utils import hash_password, verify_password, create_access_token, create_refresh_token
 
 init_db()
-ROOT_PATH = os.getenv("ROOT_PATH", "/auth")
+ROOT_PATH = os.getenv("ROOT_PATH", "")
 app = FastAPI(
     title="Auth Service",
     root_path=ROOT_PATH,
-    docs_url=f"{ROOT_PATH}/docs" if ROOT_PATH else "/docs",
-    redoc_url=f"{ROOT_PATH}/redoc" if ROOT_PATH else "/redoc",
-    openapi_url=f"{ROOT_PATH}/openapi.json" if ROOT_PATH else "/openapi.json",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
 )
 
 

--- a/services/notification/app/main.py
+++ b/services/notification/app/main.py
@@ -8,13 +8,13 @@ from typing import List
 from .database import get_session, Base, engine
 from . import crud, schemas, models
 
-ROOT_PATH = os.getenv("ROOT_PATH", "/notification")
+ROOT_PATH = os.getenv("ROOT_PATH", "")
 app = FastAPI(
     title="Notification Service",
     root_path=ROOT_PATH,
-    docs_url=f"{ROOT_PATH}/docs" if ROOT_PATH else "/docs",
-    redoc_url=f"{ROOT_PATH}/redoc" if ROOT_PATH else "/redoc",
-    openapi_url=f"{ROOT_PATH}/openapi.json" if ROOT_PATH else "/openapi.json",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
 )
 
 app.add_middleware(

--- a/services/profile/app/main.py
+++ b/services/profile/app/main.py
@@ -10,13 +10,13 @@ from . import models, schemas, crud
 
 Base.metadata.create_all(bind=engine)
 
-ROOT_PATH = os.getenv("ROOT_PATH", "/profile")
+ROOT_PATH = os.getenv("ROOT_PATH", "")
 app = FastAPI(
     title="Profile Service",
     root_path=ROOT_PATH,
-    docs_url=f"{ROOT_PATH}/docs" if ROOT_PATH else "/docs",
-    redoc_url=f"{ROOT_PATH}/redoc" if ROOT_PATH else "/redoc",
-    openapi_url=f"{ROOT_PATH}/openapi.json" if ROOT_PATH else "/openapi.json",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
 )
 
 


### PR DESCRIPTION
## Summary
- simplify root paths for FastAPI apps
- keep docs on `/docs` so the gateway proxies correctly

## Testing
- `pytest -q services/analytics/tests services/notification/tests services/profile/tests`

------
https://chatgpt.com/codex/tasks/task_e_686be8a6e5948330b32fa2350a683569