### PR TITLE
Fix docs path via ROOT_PATH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
   auth:
     build: ./services/auth
     env_file: .env
+    environment:
+      - ROOT_PATH=/auth
     depends_on:
       - postgres
     ports:
@@ -37,6 +39,8 @@ services:
   profile:
     build: ./services/profile
     env_file: .env
+    environment:
+      - ROOT_PATH=/profile
     depends_on:
       - postgres
     ports:
@@ -45,6 +49,8 @@ services:
   content:
     build: ./services/content
     env_file: .env
+    environment:
+      - ROOT_PATH=/content
     depends_on:
       - postgres
     ports:
@@ -53,6 +59,8 @@ services:
   chat:
     build: ./services/chat
     env_file: .env
+    environment:
+      - ROOT_PATH=/chat
     depends_on:
       - postgres
       - redis
@@ -62,6 +70,8 @@ services:
   notification:
     build: ./services/notification
     env_file: .env
+    environment:
+      - ROOT_PATH=/notification
     depends_on:
       - postgres
       - redis
@@ -72,6 +82,8 @@ services:
   analytics:
     build: ./services/analytics
     env_file: .env
+    environment:
+      - ROOT_PATH=/analytics
     depends_on:
       - postgres
       - rabbitmq

--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -28,3 +28,4 @@ WebSocket connections should use the path `/ws/chats/:chatId`.
 ## API Documentation
 
 When running in development you can view Swagger UI at `http://localhost:3000/docs`.
+When using Docker Compose and the Nginx gateway open `http://localhost:8080/chat/docs`.

--- a/services/chat/swagger.json
+++ b/services/chat/swagger.json
@@ -4,6 +4,9 @@
     "title": "Chat Service API",
     "version": "0.1.0"
   },
+  "servers": [
+    { "url": "/chat" }
+  ],
   "paths": {
     "/api/chats": {
       "get": {

--- a/services/content/swagger.json
+++ b/services/content/swagger.json
@@ -4,6 +4,9 @@
     "title": "Content Service API",
     "version": "0.1.0"
   },
+  "servers": [
+    { "url": "/content" }
+  ],
   "paths": {
     "/api/courses": {
       "get": { "summary": "List courses", "responses": { "200": { "description": "List of courses" } } },


### PR DESCRIPTION
## Summary
- configure ROOT_PATH per service in docker compose
- document docs endpoint for chat service
- add `servers` entry in chat and content swagger files so `/chat/docs` and `/content/docs` work

## Testing
- `pip install -r services/auth/requirements.txt`
- `pytest services/auth/tests`
- `pip install -r services/profile/requirements.txt`
- `pytest services/profile/tests`
- `pip install -r services/notification/requirements.txt`
- `pytest services/notification/tests`
- `pip install -r services/analytics/requirements.txt`
- `pytest services/analytics/tests`
- `npm install && npm test` in `services/chat`
- `go test ./...` in `services/content`


------
https://chatgpt.com/codex/tasks/task_e_686beec080848330be01af26a0ebb6e9