### PR TITLE
Improve chat & content swagger

### DIFF
--- a/services/chat/README.md
+++ b/services/chat/README.md
@@ -29,3 +29,13 @@ WebSocket connections should use the path `/ws/chats/:chatId`.
 
 When running in development you can view Swagger UI at `http://localhost:3000/docs`.
 When using Docker Compose and the Nginx gateway open `http://localhost:8080/chat/docs`.
+
+### Methods
+- [List chats](docs/#/Chats/listChats)
+- [Create chat](docs/#/Chats/createChat)
+- [Add participant](docs/#/Participants/addParticipant)
+- [Remove participant](docs/#/Participants/removeParticipant)
+- [List messages](docs/#/Messages/listMessages)
+- [Send message](docs/#/Messages/createMessage)
+- [Edit message](docs/#/Messages/editMessage)
+- [Delete message](docs/#/Messages/deleteMessage)

--- a/services/chat/swagger.json
+++ b/services/chat/swagger.json
@@ -4,103 +4,205 @@
     "title": "Chat Service API",
     "version": "0.1.0"
   },
-  "servers": [
-    { "url": "/chat" }
+  "servers": [{"url": "/chat"}],
+  "tags": [
+    {"name": "Chats", "description": "Chat management"},
+    {"name": "Participants", "description": "Participants management"},
+    {"name": "Messages", "description": "Chat messages"}
   ],
   "paths": {
     "/api/chats": {
       "get": {
         "summary": "List chats",
+        "operationId": "listChats",
+        "tags": ["Chats"],
         "responses": {
-          "200": { "description": "List of chats" }
+          "200": {
+            "description": "List of chats",
+            "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Chat"}}}}
+          }
         }
       },
       "post": {
         "summary": "Create chat",
+        "operationId": "createChat",
+        "tags": ["Chats"],
+        "requestBody": {
+          "required": false,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ChatCreate"}}}
+        },
         "responses": {
-          "201": { "description": "Chat created" }
+          "201": {
+            "description": "Chat created",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Chat"}}}
+          }
         }
       }
     },
     "/api/chats/{chatId}/participants": {
       "post": {
         "summary": "Add participant",
+        "operationId": "addParticipant",
+        "tags": ["Participants"],
         "parameters": [
-          { "name": "chatId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {"name": "chatId", "in": "path", "required": true, "schema": {"type": "string"}}
         ],
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ParticipantCreate"}}}
+        },
         "responses": {
-          "201": { "description": "Participant added" }
+          "201": {
+            "description": "Participant added",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ChatParticipant"}}}
+          }
         }
       }
     },
     "/api/chats/{chatId}/participants/{userId}": {
       "delete": {
         "summary": "Remove participant",
+        "operationId": "removeParticipant",
+        "tags": ["Participants"],
         "parameters": [
-          { "name": "chatId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "userId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {"name": "chatId", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "userId", "in": "path", "required": true, "schema": {"type": "string"}}
         ],
-        "responses": {
-          "204": { "description": "Removed" }
-        }
+        "responses": {"204": {"description": "Removed"}}
       }
     },
     "/api/chats/{chatId}/messages": {
       "get": {
         "summary": "List messages",
+        "operationId": "listMessages",
+        "tags": ["Messages"],
         "parameters": [
-          { "name": "chatId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "limit", "in": "query", "schema": { "type": "integer" } },
-          { "name": "offset", "in": "query", "schema": { "type": "integer" } }
+          {"name": "chatId", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+          {"name": "offset", "in": "query", "schema": {"type": "integer"}}
         ],
         "responses": {
-          "200": { "description": "Messages list" }
+          "200": {
+            "description": "Messages list",
+            "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Message"}}}}
+          }
         }
       },
       "post": {
         "summary": "Send message",
+        "operationId": "createMessage",
+        "tags": ["Messages"],
         "parameters": [
-          { "name": "chatId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {"name": "chatId", "in": "path", "required": true, "schema": {"type": "string"}}
         ],
         "requestBody": {
+          "required": true,
           "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "senderId": { "type": "string" },
-                  "content": { "type": "string" },
-                  "file": { "type": "string", "format": "binary" }
-                }
-              }
-            }
+            "multipart/form-data": {"schema": {"$ref": "#/components/schemas/MessageCreate"}}
           }
         },
         "responses": {
-          "201": { "description": "Message created" }
+          "201": {
+            "description": "Message created",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Message"}}}
+          }
         }
       }
     },
     "/api/chats/{chatId}/messages/{messageId}": {
       "put": {
         "summary": "Edit message",
+        "operationId": "editMessage",
+        "tags": ["Messages"],
         "parameters": [
-          { "name": "chatId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "messageId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {"name": "chatId", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "messageId", "in": "path", "required": true, "schema": {"type": "string"}}
         ],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MessageUpdate"}}}},
         "responses": {
-          "200": { "description": "Message updated" }
+          "200": {
+            "description": "Message updated",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Message"}}}
+          }
         }
       },
       "delete": {
         "summary": "Delete message",
+        "operationId": "deleteMessage",
+        "tags": ["Messages"],
         "parameters": [
-          { "name": "chatId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "messageId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {"name": "chatId", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "messageId", "in": "path", "required": true, "schema": {"type": "string"}}
         ],
-        "responses": {
-          "204": { "description": "Message deleted" }
+        "responses": {"204": {"description": "Message deleted"}}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Chat": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "createdAt": {"type": "string", "format": "date-time"},
+          "updatedAt": {"type": "string", "format": "date-time"}
         }
+      },
+      "ChatCreate": {
+        "type": "object",
+        "properties": {"title": {"type": "string"}}
+      },
+      "ChatParticipant": {
+        "type": "object",
+        "properties": {
+          "chatId": {"type": "string"},
+          "userId": {"type": "string"},
+          "joinedAt": {"type": "string", "format": "date-time"}
+        }
+      },
+      "ParticipantCreate": {
+        "type": "object",
+        "properties": {"userId": {"type": "string"}},
+        "required": ["userId"]
+      },
+      "Attachment": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "messageId": {"type": "string"},
+          "url": {"type": "string"},
+          "mimeType": {"type": "string"},
+          "sizeBytes": {"type": "integer"}
+        }
+      },
+      "Message": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "chatId": {"type": "string"},
+          "senderId": {"type": "string"},
+          "content": {"type": "string"},
+          "editedAt": {"type": "string", "format": "date-time"},
+          "deletedAt": {"type": "string", "format": "date-time"},
+          "attachments": {"type": "array", "items": {"$ref": "#/components/schemas/Attachment"}},
+          "createdAt": {"type": "string", "format": "date-time"},
+          "updatedAt": {"type": "string", "format": "date-time"}
+        }
+      },
+      "MessageCreate": {
+        "type": "object",
+        "properties": {
+          "senderId": {"type": "string"},
+          "content": {"type": "string"},
+          "file": {"type": "string", "format": "binary"}
+        },
+        "required": ["senderId"]
+      },
+      "MessageUpdate": {
+        "type": "object",
+        "properties": {"content": {"type": "string"}},
+        "required": ["content"]
       }
     }
   }

--- a/services/content/README.md
+++ b/services/content/README.md
@@ -16,3 +16,20 @@ go run .
 The service listens on port `8000` and exposes JSON endpoints under `/api`.
 Swagger UI for exploring the API is served at `http://localhost:8000/docs` or
 via the gateway at `http://localhost:8080/content/docs`.
+
+### Methods
+- [List courses](docs/#/Courses/listCourses)
+- [Create course](docs/#/Courses/createCourse)
+- [Get course](docs/#/Courses/getCourse)
+- [Update course](docs/#/Courses/updateCourse)
+- [Delete course](docs/#/Courses/deleteCourse)
+- [List sections](docs/#/Sections/listSections)
+- [Create section](docs/#/Sections/createSection)
+- [Update section](docs/#/Sections/updateSection)
+- [Delete section](docs/#/Sections/deleteSection)
+- [List materials](docs/#/Materials/listMaterials)
+- [Create material](docs/#/Materials/createMaterial)
+- [Update material](docs/#/Materials/updateMaterial)
+- [Delete material](docs/#/Materials/deleteMaterial)
+- [Check media status](docs/#/Media/getMediaStatus)
+- [Stream media](docs/#/Media/streamMedia)

--- a/services/content/swagger.json
+++ b/services/content/swagger.json
@@ -4,91 +4,247 @@
     "title": "Content Service API",
     "version": "0.1.0"
   },
-  "servers": [
-    { "url": "/content" }
+  "servers": [{"url": "/content"}],
+  "tags": [
+    {"name": "Courses"},
+    {"name": "Sections"},
+    {"name": "Materials"},
+    {"name": "Media"}
   ],
   "paths": {
     "/api/courses": {
-      "get": { "summary": "List courses", "responses": { "200": { "description": "List of courses" } } },
-      "post": { "summary": "Create course", "responses": { "201": { "description": "Course created" } } }
+      "get": {
+        "summary": "List courses",
+        "operationId": "listCourses",
+        "tags": ["Courses"],
+        "responses": {
+          "200": {
+            "description": "List of courses",
+            "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Course"}}}}
+          }
+        }
+      },
+      "post": {
+        "summary": "Create course",
+        "operationId": "createCourse",
+        "tags": ["Courses"],
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CourseCreate"}}}
+        },
+        "responses": {
+          "201": {
+            "description": "Course created",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Course"}}}
+          }
+        }
+      }
     },
     "/api/courses/{courseId}": {
       "get": {
         "summary": "Get course",
-        "parameters": [ { "name": "courseId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "200": { "description": "Course" } }
+        "operationId": "getCourse",
+        "tags": ["Courses"],
+        "parameters": [{"name": "courseId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"200": {"description": "Course", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Course"}}}}}
       },
       "put": {
         "summary": "Update course",
-        "parameters": [ { "name": "courseId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "200": { "description": "Updated" } }
+        "operationId": "updateCourse",
+        "tags": ["Courses"],
+        "parameters": [{"name": "courseId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CourseUpdate"}}}},
+        "responses": {"200": {"description": "Updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Course"}}}}}
       },
       "delete": {
         "summary": "Delete course",
-        "parameters": [ { "name": "courseId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "204": { "description": "Deleted" } }
+        "operationId": "deleteCourse",
+        "tags": ["Courses"],
+        "parameters": [{"name": "courseId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"204": {"description": "Deleted"}}
       }
     },
     "/api/courses/{courseId}/sections": {
       "get": {
         "summary": "List sections",
-        "parameters": [ { "name": "courseId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "200": { "description": "Sections" } }
+        "operationId": "listSections",
+        "tags": ["Sections"],
+        "parameters": [{"name": "courseId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"200": {"description": "Sections", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Section"}}}}}}
       },
       "post": {
         "summary": "Create section",
-        "parameters": [ { "name": "courseId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "201": { "description": "Section created" } }
+        "operationId": "createSection",
+        "tags": ["Sections"],
+        "parameters": [{"name": "courseId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/SectionCreate"}}}},
+        "responses": {"201": {"description": "Section created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Section"}}}}}
       }
     },
     "/api/sections/{sectionId}": {
       "put": {
         "summary": "Update section",
-        "parameters": [ { "name": "sectionId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "200": { "description": "Updated" } }
+        "operationId": "updateSection",
+        "tags": ["Sections"],
+        "parameters": [{"name": "sectionId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/SectionUpdate"}}}},
+        "responses": {"200": {"description": "Updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Section"}}}}}
       },
       "delete": {
         "summary": "Delete section",
-        "parameters": [ { "name": "sectionId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "204": { "description": "Deleted" } }
+        "operationId": "deleteSection",
+        "tags": ["Sections"],
+        "parameters": [{"name": "sectionId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"204": {"description": "Deleted"}}
       }
     },
     "/api/sections/{sectionId}/materials": {
       "get": {
         "summary": "List materials",
-        "parameters": [ { "name": "sectionId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "200": { "description": "Materials" } }
+        "operationId": "listMaterials",
+        "tags": ["Materials"],
+        "parameters": [{"name": "sectionId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"200": {"description": "Materials", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Material"}}}}}}
       },
       "post": {
         "summary": "Create material",
-        "parameters": [ { "name": "sectionId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "201": { "description": "Material created" } }
+        "operationId": "createMaterial",
+        "tags": ["Materials"],
+        "parameters": [{"name": "sectionId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MaterialCreate"}}}},
+        "responses": {"201": {"description": "Material created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Material"}}}}}
       }
     },
     "/api/materials/{materialId}": {
       "put": {
         "summary": "Update material",
-        "parameters": [ { "name": "materialId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "200": { "description": "Updated" } }
+        "operationId": "updateMaterial",
+        "tags": ["Materials"],
+        "parameters": [{"name": "materialId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MaterialUpdate"}}}},
+        "responses": {"200": {"description": "Updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Material"}}}}}
       },
       "delete": {
         "summary": "Delete material",
-        "parameters": [ { "name": "materialId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "204": { "description": "Deleted" } }
+        "operationId": "deleteMaterial",
+        "tags": ["Materials"],
+        "parameters": [{"name": "materialId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"204": {"description": "Deleted"}}
       }
     },
     "/api/media/{mediaId}/status": {
       "get": {
         "summary": "Check media status",
-        "parameters": [ { "name": "mediaId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "200": { "description": "Status" } }
+        "operationId": "getMediaStatus",
+        "tags": ["Media"],
+        "parameters": [{"name": "mediaId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"200": {"description": "Status", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MediaStatus"}}}}}
       }
     },
     "/api/media/{mediaId}/stream": {
       "get": {
         "summary": "Stream media",
-        "parameters": [ { "name": "mediaId", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "responses": { "302": { "description": "Redirect" } }
+        "operationId": "streamMedia",
+        "tags": ["Media"],
+        "parameters": [{"name": "mediaId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"302": {"description": "Redirect"}}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Course": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "description": {"type": "string"},
+          "language": {"type": "string"},
+          "status": {"type": "string"},
+          "visibility": {"type": "string"},
+          "tags": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "CourseCreate": {
+        "type": "object",
+        "properties": {
+          "title": {"type": "string"},
+          "description": {"type": "string"},
+          "language": {"type": "string"},
+          "status": {"type": "string"},
+          "visibility": {"type": "string"},
+          "tags": {"type": "array", "items": {"type": "string"}}
+        },
+        "required": ["title"]
+      },
+      "CourseUpdate": {
+        "type": "object",
+        "properties": {
+          "title": {"type": "string"},
+          "description": {"type": "string"},
+          "language": {"type": "string"},
+          "status": {"type": "string"},
+          "visibility": {"type": "string"},
+          "tags": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "Section": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "course_id": {"type": "string"},
+          "title": {"type": "string"},
+          "sequence": {"type": "integer"}
+        }
+      },
+      "SectionCreate": {
+        "type": "object",
+        "properties": {
+          "title": {"type": "string"},
+          "sequence": {"type": "integer"}
+        },
+        "required": ["title"]
+      },
+      "SectionUpdate": {
+        "type": "object",
+        "properties": {
+          "title": {"type": "string"},
+          "sequence": {"type": "integer"}
+        }
+      },
+      "Material": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "section_id": {"type": "string"},
+          "type": {"type": "string"},
+          "title": {"type": "string"},
+          "status": {"type": "string"}
+        }
+      },
+      "MaterialCreate": {
+        "type": "object",
+        "properties": {
+          "type": {"type": "string"},
+          "title": {"type": "string"},
+          "status": {"type": "string"}
+        },
+        "required": ["type", "title"]
+      },
+      "MaterialUpdate": {
+        "type": "object",
+        "properties": {
+          "title": {"type": "string"},
+          "status": {"type": "string"}
+        }
+      },
+      "MediaStatus": {
+        "type": "object",
+        "properties": {
+          "media_file_id": {"type": "string"},
+          "status": {"type": "string"},
+          "url": {"type": "string"}
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- document chat endpoints with detailed schemas
- document content endpoints with detailed schemas
- link swagger methods from service READMEs

## Testing
- `npm test` in `services/chat`
- `go test ./...` in `services/content`

------
https://chatgpt.com/codex/tasks/task_e_686bfbdda158833099eee1b4dc10c0c4