### PR TITLE
Add layout and login page

### DIFF
--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn } from 'next-auth/react'
+import Button from '@/components/Button'
+import Input from '@/components/Input'
+
+export default function LoginPage() {
+  const [tab, setTab] = useState<'phone' | 'email'>('phone')
+  const [phone, setPhone] = useState('')
+  const [code, setCode] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleEmail = async () => {
+    await signIn('credentials', { email, password, redirect: false })
+  }
+
+  const handlePhone = async () => {
+    await signIn('credentials', { phone, password: code, redirect: false })
+  }
+
+  return (
+    <div className="max-w-sm mx-auto p-4 space-y-4">
+      <div className="flex space-x-2">
+        <button
+          onClick={() => setTab('phone')}
+          className={tab === 'phone' ? 'font-bold' : ''}
+        >
+          Phone
+        </button>
+        <button
+          onClick={() => setTab('email')}
+          className={tab === 'email' ? 'font-bold' : ''}
+        >
+          Email
+        </button>
+      </div>
+
+      {tab === 'phone' ? (
+        <div className="space-y-2">
+          <Input
+            placeholder="+7..."
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+          />
+          <Input
+            placeholder="Code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+          />
+          <Button onClick={handlePhone}>Login</Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <Input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button onClick={handleEmail}>Login</Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/app/courses/page.tsx
+++ b/frontend/src/app/courses/page.tsx
@@ -1,3 +1,18 @@
-export default function Page() {
-  return <div>courses page</div>
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { listCourses } from '@/lib/content'
+import CourseList from '@/components/CourseList'
+
+export default function CoursesPage() {
+  const { data } = useQuery({
+    queryKey: ['courses'],
+    queryFn: () => listCourses().then((res) => res.data),
+  })
+
+  return (
+    <div className="p-4">
+      <CourseList courses={data ?? []} />
+    </div>
+  )
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import QueryClientProviderWrapper from "../components/QueryClientProviderWrapper";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import { SessionProvider } from "next-auth/react";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,8 +28,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <QueryClientProviderWrapper>{children}</QueryClientProviderWrapper>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}>
+        <SessionProvider>
+          <QueryClientProviderWrapper>
+            <Header />
+            <main className="flex-1">{children}</main>
+            <Footer />
+          </QueryClientProviderWrapper>
+        </SessionProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,6 +1,13 @@
-export default function Button({ children }: { children: React.ReactNode }) {
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode
+}
+
+export default function Button({ children, ...props }: Props) {
   return (
-    <button className="px-4 py-2 bg-blue-600 text-white rounded">
+    <button
+      {...props}
+      className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+    >
       {children}
     </button>
   )

--- a/frontend/src/components/CourseList.tsx
+++ b/frontend/src/components/CourseList.tsx
@@ -1,0 +1,12 @@
+import CourseCard from './CourseCard'
+
+export default function CourseList({ courses }: { courses: any[] }) {
+  if (!courses?.length) return <p>No courses</p>
+  return (
+    <div className="grid gap-4">
+      {courses.map((c) => (
+        <CourseCard key={c.id} title={c.title} description={c.description} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="p-4 border-t text-center text-sm mt-auto">
+      © {new Date().getFullYear()} <a href="/privacy">Privacy Policy</a>
+    </footer>
+  )
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import Link from 'next/link'
+import { useSession, signOut } from 'next-auth/react'
+
+export default function Header() {
+  const { data: session } = useSession()
+
+  return (
+    <header className="flex items-center justify-between p-4 border-b">
+      <Link href="/courses" className="font-bold">
+        Logo
+      </Link>
+      <nav className="space-x-4">
+        <Link href="/courses">Courses</Link>
+        <Link href="/chat">Chat</Link>
+        <Link href="/notification">Notifications</Link>
+        <Link href="/analytics">Analytics</Link>
+        {session && <Link href="/profile">Profile</Link>}
+      </nav>
+      {session ? (
+        <button onClick={() => signOut()} className="text-sm">
+          Logout
+        </button>
+      ) : (
+        <Link href="/auth/login">Login</Link>
+      )}
+    </header>
+  )
+}

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -1,0 +1,12 @@
+export default function Input(
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) {
+  return (
+    <input
+      {...props}
+      className={
+        'border rounded px-3 py-2 w-full ' + (props.className ?? '')
+      }
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- add `Header` and `Footer` components and wire them into `layout.tsx`
- create basic login page with phone and email tabs
- display courses fetched from backend
- expand button component to accept props

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d538ef7c08330964a0a93797eb59f